### PR TITLE
feat: agregar autenticacion Header Auth a la prueba de integracion n8n

### DIFF
--- a/.github/workflows/n8n-validate-ci.yml
+++ b/.github/workflows/n8n-validate-ci.yml
@@ -68,7 +68,11 @@ jobs:
         if: steps.check_n8n.outputs.skip == 'false'
         env:
           N8N_API_URL: ${{ secrets.N8N_API_URL }}
+          N8N_WEBHOOK_KEY: ${{ secrets.N8N_WEBHOOK_KEY }}
         run: |
-          RESPUESTA=$(curl -s -X POST "$N8N_API_URL" -H "Content-Type: application/json" -d '{"test":"true"}')
+          RESPUESTA=$(curl -s -X POST "$N8N_API_URL" \
+            -H "Content-Type: application/json" \
+            -H "X-N8N-Webhook-Key: $N8N_WEBHOOK_KEY" \
+            -d '{"test":"true"}')
           echo "Respuesta de n8n: $RESPUESTA"
           echo "$RESPUESTA" | grep -q '"status":"ok"' && echo "✅ Integración exitosa" || (echo "❌ n8n no respondió como se esperaba" && exit 1)


### PR DESCRIPTION
## Descripción del cambio
Se agregó autenticación real (Header Auth) al webhook de n8n usado para la prueba de integración del pipeline de CI/CD. Antes, el webhook estaba abierto sin ninguna credencial, lo cual no era seguro para un proyecto de salud pública. Ahora la solicitud desde GitHub Actions incluye un header secreto (X-N8N-Webhook-Key) que n8n valida antes de responder.

## Issue relacionado


## Autor y rol
- **Nombre:** Herbert Jhon Choqqueccota Cahui
- **Rol en la célula:** DevSecOps

## Tipo de cambio
- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor (sin cambio de funcionalidad)
- [ ] Documentación / ADR
- [x] Infraestructura / CI-CD
- [ ] Base de datos (migración SQL)
- [ ] Workflow de n8n (JSON exportado)
- [ ] Prompt Engineering (ia-ops)

## Archivos modificados
- `.github/workflows/n8n-validate-ci.yml` — se agregó el secret N8N_WEBHOOK_KEY y el header X-N8N-Webhook-Key en la llamada curl del job validate-live-connection.

## Verificación de seguridad
- [x] No hay credenciales, tokens ni API keys escritos en el código fuente
- [x] No hay archivos `.env` incluidos en el commit
- [x] Las variables sensibles están en `.env`, no en el `docker-compose.yml`
- [x] Las rutas de API de Next.js no exponen URLs de webhook al navegador (`NEXT_PUBLIC_` no se usó para credenciales)
- [x] Si se modificó un JSON de n8n, no contiene credenciales en texto plano dentro del JSON

## Cumplimiento de arquitectura
- [x] El Frontend no llama directamente a PostgreSQL ni a ninguna API de IA
- [x] Todo flujo de datos pasa por n8n (Frontend → /api/query → n8n → DB/LLM) (ADR-001/004)
- [ ] Los flujos de IA respetan la división por momento de operación: Gemini Flash para ingesta PDF y Claude Haiku para consultas NLQ (ADR-003) 
- [ ] Si se modificó el `docker-compose.yml`, solo el Frontend expone puerto público al host por defecto (ADR-008) 
- [ ] Si se agregó un workflow de n8n, el JSON exportado está en `src/n8n-workflows/` 
- [ ] Si se agregaron o modificaron prompts, están versionados en `src/ia-ops/prompts/` y no hardcodeados 
- [ ] Si se invocó un LLM en n8n, el workflow incluye el nodo de envío de traza a Arize Phoenix (ADR-010) 
- [ ] Si se crearon o modificaron tablas, las migraciones SQL están en `src/database/migrations/` (ADR-002) 

## Pruebas realizadas
Se configuró autenticación Header Auth en el nodo Webhook del workflow "CI - Prueba de Integracion n8n" (instancia self-hosted en n8n cloud), con credencial X-N8N-Webhook-Key. Se creó el secret N8N_WEBHOOK_KEY en GitHub y se actualizó el curl del job validate-live-connection para enviar ese header. Se ejecutó el pipeline en el PR de prueba y el check "Validación contra instancia n8n (opcional)" pasó de Failing a Successful, confirmando que la autenticación funciona correctamente de punta a punta.

## Nota para el Arquitecto
El webhook de prueba actual vive únicamente en la instancia personal de n8n (herbert-chc21.app.n8n.cloud) y no está exportado como JSON en el repositorio, a diferencia de los demás workflows de n8n. Es un workflow de prueba para validar el patrón de integración del pipeline, no el flujo de producción real. Cuando Backend defina el webhook definitivo del proyecto, habrá que repetir este mismo patrón (Header Auth + secrets en GitHub) apuntando a esa instancia, y exportar el JSON correspondiente a src/n8n-workflows/production/.

## Checklist antes de solicitar revisión
- [x] El código corre localmente sin errores
- [x] Los pipelines de GitHub Actions pasan (verde)
- [ ] El PR tiene el ID del Issue en la sección "Issue relacionado"
- [x] El título del PR describe claramente el cambio
- [ ] Se asignó al Arquitecto como Reviewer en GitHub