### PR TITLE
feat: versiona workflow de prueba de integracion n8n (HU-04)

### DIFF
--- a/src/n8n-workflows/production/ci-webhook-integration-test.json
+++ b/src/n8n-workflows/production/ci-webhook-integration-test.json
@@ -1,0 +1,72 @@
+{
+  "name": "CI - Prueba de Integracion",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "657f267f-0288-451d-93f4-68a0ac1dd254",
+        "authentication": "headerAuth",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2.1,
+      "position": [
+        0,
+        0
+      ],
+      "id": "a6a0def7-14ae-4534-9572-82626752b714",
+      "name": "Webhook",
+      "webhookId": "657f267f-0288-451d-93f4-68a0ac1dd254",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "XLsGOSOFYURHEENX",
+          "name": "Header Auth account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "{\n  \"status\": \"ok\",\n  \"mensaje\": \"n8n recibió la solicitud\"\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.5,
+      "position": [
+        224,
+        0
+      ],
+      "id": "74f9c4e2-9944-4bdd-935b-1b94c0c08a5d",
+      "name": "Respond to Webhook"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": true,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate",
+    "availableInMCP": false
+  },
+  "versionId": "f9217d25-cabd-4c55-a9bc-46215bfbf7bd",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "2b7019baa3735a09549a0e5df300dffd94a7b3c8fb5098fe26e0a5a3cb780366"
+  },
+  "nodeGroups": [],
+  "id": "1qMqPcIOojE48tqu",
+  "tags": []
+}


### PR DESCRIPTION
## Descripción del cambio
Se exportó y versionó en el repositorio el workflow de prueba de integración con n8n (nodo Webhook + Respond to Webhook con autenticación Header Auth), que hasta ahora solo existía en la cuenta personal de n8n cloud sin ningún respaldo en control de versiones. Con esto, el workflow queda documentado y trazable igual que los demás workflows de n8n del proyecto.

## Issue relacionado
Closes #49 

## Autor y rol
- **Nombre:** Herbert Jhon Choqqueccota Cahui
- **Rol en la célula:** DevSecOps

## Tipo de cambio
- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor (sin cambio de funcionalidad)
- [ ] Documentación / ADR
- [ ] Infraestructura / CI-CD
- [x] Workflow de n8n (JSON exportado)
- [ ] Base de datos (migración SQL)
- [ ] Prompt Engineering (ia-ops)

## Archivos modificados
- `src/n8n-workflows/production/ci-webhook-integration-test.json` — exportación del workflow "CI - Prueba de Integracion", con nodo Webhook (POST, Header Auth) y nodo Respond to Webhook devolviendo la confirmación JSON usada por el pipeline de CI.

## Verificación de seguridad
- [x] No hay credenciales, tokens ni API keys escritos en el código fuente
- [x] No hay archivos `.env` incluidos en el commit
- [x] Las variables sensibles están en `.env`, no en el `docker-compose.yml`
- [x] Las rutas de API de Next.js no exponen URLs de webhook al navegador (`NEXT_PUBLIC_` no se usó para credenciales)
- [x] Si se modificó un JSON de n8n, no contiene credenciales en texto plano dentro del JSON — el bloque `credentials.httpHeaderAuth` solo referencia el `id` y `name` de la credencial almacenada en n8n, no el valor secreto.

## Cumplimiento de arquitectura
- [x] El Frontend no llama directamente a PostgreSQL ni a ninguna API de IA
- [x] Todo flujo de datos pasa por n8n (Frontend → /api/query → n8n → DB/LLM) (ADR-001/004)
- [ ] Los flujos de IA respetan la división por momento de operación: Gemini Flash para ingesta PDF y Claude Haiku para consultas NLQ (ADR-003) — *no aplica a este cambio*
- [ ] Si se modificó el `docker-compose.yml`, solo el Frontend expone puerto público al host por defecto (ADR-008) — *no aplica*
- [x] Si se agregó un workflow de n8n, el JSON exportado está en `src/n8n-workflows/`
- [ ] Si se agregaron o modificaron prompts, están versionados en `src/ia-ops/prompts/` y no hardcodeados — *no aplica*
- [ ] Si se invocó un LLM en n8n, el workflow incluye el nodo de envío de traza a Arize Phoenix (ADR-010) — *no aplica, este workflow de prueba no invoca ningún LLM*
- [ ] Si se crearon o modificaron tablas, las migraciones SQL están en `src/database/migrations/` (ADR-002) — *no aplica*

## Pruebas realizadas
Se exportó el workflow desde n8n usando "Download" en formato JSON y se agregó tal cual al repositorio, sin editar manualmente su contenido. Se verificó que el JSON sea válido corriendo localmente `python3 -m json.tool` sobre el archivo, y se confirmó en el PR que el check "Validar JSONs de n8n" pasa en verde al detectar el nuevo archivo dentro de la ruta vigilada por `dorny/paths-filter`.

## Nota para el Arquitecto
Este es el workflow de prueba que usé para validar el patrón de integración (Header Auth + secrets en GitHub), no el workflow definitivo de producción. Cuando se defina el webhook oficial del proyecto sobre la instancia de n8n que administras en Azure, habrá que repetir este mismo paso de exportación con ese workflow real.

## Checklist antes de solicitar revisión
- [x] El código corre localmente sin errores
- [x] Los pipelines de GitHub Actions pasan (verde)
- [ ] El PR tiene el ID del Issue en la sección "Issue relacionado" — *coloca el número real*
- [x] El título del PR describe claramente el cambio
- [ ] Se asignó al Arquitecto como Reviewer en GitHub — *hazlo al crear/actualizar el PR*