### PR TITLE
fix: agregar header ngrok-skip-browser-warning en validacion de n8n

### DIFF
--- a/.github/workflows/n8n-validate-ci.yml
+++ b/.github/workflows/n8n-validate-ci.yml
@@ -58,23 +58,20 @@ jobs:
       - name: Verificar si hay credenciales de n8n configuradas
         id: check_n8n
         run: |
-          if [ -z "${{ secrets.N8N_API_URL }}" ] || [ -z "${{ secrets.N8N_WEBHOOK_KEY }}" ]; then
+          if [ -z "${{ secrets.AZURE_VM_HOST }}" ] || [ -z "${{ secrets.AZURE_VM_SSH_KEY }}" ] || [ -z "${{ secrets.AZURE_VM_USER }}" ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
-            echo "ℹ️ Secrets N8N_API_URL / N8N_WEBHOOK_KEY no configurados — se omite la validación en vivo"
+            echo "ℹ️ Secrets AZURE_VM_HOST / AZURE_VM_SSH_KEY / AZURE_VM_USER no configurados — se omite la validación en vivo"
           else
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Probar conexión con la instancia n8n (informativo)
-        if: steps.check_n8n.outputs.skip == 'false'
-        env:
-          N8N_API_URL: ${{ secrets.N8N_API_URL }}
-          N8N_WEBHOOK_KEY: ${{ secrets.N8N_WEBHOOK_KEY }}
-        run: |
-          echo "ℹ️ Intentando conexión con la instancia n8n..."
-          if curl -sf --max-time 10 -X POST -H "X-N8N-Webhook-Key: $N8N_WEBHOOK_KEY" -H "ngrok-skip-browser-warning: true" "$N8N_API_URL/webhook/657f267f-0288-451d-93f4-68a0ac1dd254" > /dev/null; then
-            echo "✅ Conexión exitosa con n8n"
-          else
-            echo "⚠️ No se pudo conectar a la instancia n8n (esperado: es una instancia local, no accesible desde GitHub Actions)."
-            echo "   Validación omitida. Este check es informativo y no bloquea el merge."
-          fi
+      - name: Verificar que n8n esté activo en la VM Azure
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.AZURE_VM_HOST }}
+          username: ${{ secrets.AZURE_VM_USER }}
+          key: ${{ secrets.AZURE_VM_SSH_KEY }}
+          script: |
+            docker inspect --format '{{.State.Status}}' healthradar-n8n | grep -q running || (echo "❌ n8n no está corriendo" && exit 1)
+            docker exec healthradar-n8n wget -qO- http://localhost:5678/healthz || (echo "❌ n8n no responde" && exit 1)
+            echo "✅ n8n está activo y respondiendo"

--- a/.github/workflows/n8n-validate-ci.yml
+++ b/.github/workflows/n8n-validate-ci.yml
@@ -64,6 +64,7 @@ jobs:
           else
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
+
       - name: Probar conexión con la instancia n8n (informativo)
         if: steps.check_n8n.outputs.skip == 'false'
         env:
@@ -71,7 +72,7 @@ jobs:
           N8N_WEBHOOK_KEY: ${{ secrets.N8N_WEBHOOK_KEY }}
         run: |
           echo "ℹ️ Intentando conexión con la instancia n8n..."
-          if curl -sf --max-time 10 -X POST -H "X-N8N-Webhook-Key: $N8N_WEBHOOK_KEY" "$N8N_API_URL/webhook/657f267f-0288-451d-93f4-68a0ac1dd254" > /dev/null; then
+          if curl -sf --max-time 10 -X POST -H "X-N8N-Webhook-Key: $N8N_WEBHOOK_KEY" -H "ngrok-skip-browser-warning: true" "$N8N_API_URL/webhook/657f267f-0288-451d-93f4-68a0ac1dd254" > /dev/null; then
             echo "✅ Conexión exitosa con n8n"
           else
             echo "⚠️ No se pudo conectar a la instancia n8n (esperado: es una instancia local, no accesible desde GitHub Actions)."

--- a/.github/workflows/n8n-validate-ci.yml
+++ b/.github/workflows/n8n-validate-ci.yml
@@ -66,6 +66,7 @@ jobs:
           fi
 
       - name: Verificar que n8n esté activo en la VM Azure
+        if: steps.check_n8n.outputs.skip == 'false'
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.AZURE_VM_HOST }}


### PR DESCRIPTION
## Descripción del cambio
Se corrige el mecanismo de validación en vivo del job `validate-live-connection` en `n8n-validate-ci.yml`. La implementación anterior exponía una instancia local de n8n a internet mediante un túnel de ngrok, lo cual contradice ADR-008/ADR-011 (n8n no debe exponer puertos públicos; solo el Frontend y el puerto SSH de administración están permitidos). Se rediseñó el mecanismo por completo: ahora el pipeline se conecta por SSH a la VM oficial de Azure usando una llave dedicada exclusivamente para GitHub Actions (`healthradar_gha_deploy`, generada aparte de las llaves personales del equipo), y valida el estado del contenedor `healthradar-n8n` directamente desde dentro de la VM — primero confirmando que el contenedor está corriendo (`docker inspect`) y luego que el servicio responde en su endpoint de salud (`docker exec ... wget http://localhost:5678/healthz`). No se expone ningún puerto de n8n a internet en ningún momento del proceso.

## Issue relacionado
Closes [#50](https://github.com/Equipo5-Aqp/HealthRadar/issues/50)

## Autor y rol
- **Nombre:** Herbert Jhon Choqqueccota Cahui
- **Rol en la célula:** DevSecOps

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de bug
- [ ] Refactor (sin cambio de funcionalidad)
- [ ] Documentación / ADR
- [x] Infraestructura / CI-CD
- [ ] Base de datos (migración SQL)
- [ ] Workflow de n8n (JSON exportado)
- [ ] Prompt Engineering (ia-ops)

## Archivos modificados
- `.github/workflows/n8n-validate-ci.yml` — se reemplazó el step que hacía `curl` directo vía ngrok por un step con `appleboy/ssh-action` que se conecta a la VM de Azure y valida el contenedor `healthradar-n8n` internamente (`docker inspect` + `docker exec ... /healthz`); se agregó la condición `if: steps.check_n8n.outputs.skip == 'false'` para que el step se omita limpiamente cuando faltan los secrets de acceso.

## Verificación de seguridad
- [x] No hay credenciales, tokens ni API keys escritos en el código fuente
- [x] No hay archivos `.env` incluidos en el commit
- [x] Las variables sensibles están en `.env`, no en el `docker-compose.yml`
- [x] Las rutas de API de Next.js no exponen URLs de webhook al navegador (`NEXT_PUBLIC_` no se usó para credenciales)
- [x] Si se modificó un JSON de n8n, no contiene credenciales en texto plano dentro del JSON

## Cumplimiento de arquitectura
- [x] El Frontend no llama directamente a PostgreSQL ni a ninguna API de IA
- [x] Todo flujo de datos pasa por n8n (Frontend → /api/query → n8n → DB/LLM) (ADR-001/004)
- [ ] Los flujos de IA respetan la división por momento de operación: Gemini Flash para ingesta PDF y Claude Haiku para consultas NLQ (ADR-003) 
- [x] Si se modificó el `docker-compose.yml`, solo el Frontend expone puerto público al host por defecto (ADR-008) 
- [ ] Si se agregó un workflow de n8n, el JSON exportado está en `src/n8n-workflows/` — *no aplica a este PR*
- [ ] Si se agregaron o modificaron prompts, están versionados en `src/ia-ops/prompts/` y no hardcodeados 
- [ ] Si se invocó un LLM en n8n, el workflow incluye el nodo de envío de traza a Arize Phoenix (ADR-010) 
- [ ] Si se crearon o modificaron tablas, las migraciones SQL están en `src/database/migrations/` (ADR-002) 
## Pruebas realizadas
Se generó una llave SSH dedicada exclusivamente para GitHub Actions (`healthradar_gha_deploy`, ed25519), separada de las llaves personales del equipo. El Arquitecto autorizó la clave pública en la VM oficial de Azure (`20.9.78.118`, usuario `azureuser`). Se configuraron los secrets `AZURE_VM_HOST`, `AZURE_VM_USER` y `AZURE_VM_SSH_KEY` en GitHub Actions. Se confirmó manualmente desde PowerShell que la conexión SSH a la VM funciona correctamente con la llave dedicada, sin necesidad de contraseña. Se corrigió el script para validar directamente el contenedor `healthradar-n8n` (estado + endpoint `/healthz`) en lugar de depender de un webhook de negocio específico, ya que los workflows del proyecto aún están en versión preliminar y ninguno está desplegado en producción. **Pendiente:** confirmar en la pestaña Actions que el job corre limpio de extremo a extremo con este ajuste.

## Nota para el Arquitecto
Este PR reemplaza por completo el mecanismo de validación en vivo de HU-05: ya no depende de ngrok ni de exponer n8n a internet, sino de una conexión SSH con una llave dedicada solo para CI, validando el contenedor real (`healthradar-n8n`) desde dentro de la VM. Como los workflows de negocio siguen en versión preliminar, el chequeo valida solo que el servicio esté disponible (`/healthz`), no un webhook específico; cuando Full Stack despliegue el primer workflow real, se puede ajustar para validar ese endpoint concreto si se considera necesario.

## Checklist antes de solicitar revisión
- [x] El código corre localmente sin errores
- [ ] Los pipelines de GitHub Actions pasan (verde)
- [x] El PR tiene el ID del Issue en la sección "Issue relacionado"
- [x] El título del PR describe claramente el cambio
- [ ] Se asignó al Arquitecto como Reviewer en GitHub