### PR TITLE
feat: agrega CODEOWNERS para n8n-workflows e ia-ops (HU-06)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS - HealthRadar
+# Cada línea asigna revisores obligatorios para las rutas indicadas.
+# Ver: https://docs.github.com/articles/about-code-owners
+
+# Workflows de n8n - requiere revisión de Backend/Full Stack
+/src/n8n-workflows/ @Andy-2214
+
+# Prompts de IA - requiere revisión de QA/Prompt Engineer
+/src/ia-ops/ @edgvrz


### PR DESCRIPTION
## Descripción del cambio
Se endurecen las reglas de protección de la rama `main` para reflejar que ahora varios integrantes contribuyen en paralelo al repositorio. Se agrega un archivo `CODEOWNERS` que asigna revisores obligatorios para las carpetas críticas del proyecto: `src/n8n-workflows/` (workflows de n8n) requiere revisión de Backend/Full Stack, y `src/ia-ops/` (prompts de IA) requiere revisión de QA/Prompt Engineer. Se activa la opción "Require review from Code Owners" en Branch Protection Rules para que estas revisiones sean obligatorias antes de fusionar a `main`. Adicionalmente, se evaluaron dos reglas adicionales ("Require signed commits" y "Restrict who can push to matching branches"), documentando la decisión de no activarlas por ahora.

## Issue relacionado
Closes #51 

## Autor y rol
- **Nombre:** Herbert Jhon Choqqueccota Cahui
- **Rol en la célula:** DevSecOps

## Tipo de cambio
- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor (sin cambio de funcionalidad)
- [x] Documentación / ADR
- [x] Infraestructura / CI-CD
- [ ] Base de datos (migración SQL)
- [ ] Workflow de n8n (JSON exportado)
- [ ] Prompt Engineering (ia-ops)

## Archivos modificados
- `.github/CODEOWNERS` — nuevo archivo que asigna `@Andy-2214` como revisor obligatorio de `src/n8n-workflows/` y `@edgvrz` como revisor obligatorio de `src/ia-ops/`.

## Verificación de seguridad
- [x] No hay credenciales, tokens ni API keys escritos en el código fuente
- [x] No hay archivos `.env` incluidos en el commit
- [x] Las variables sensibles están en `.env`, no en el `docker-compose.yml`
- [ ] Las rutas de API de Next.js no exponen URLs de webhook al navegador
- [ ] Si se modificó un JSON de n8n, no contiene credenciales en texto plano dentro del JSON

## Cumplimiento de arquitectura
- [ ] El Frontend no llama directamente a PostgreSQL ni a ninguna API de IA
- [ ] Todo flujo de datos pasa por n8n (Frontend → /api/query → n8n → DB/LLM) (ADR-001/004) 
- [ ] Los flujos de IA respetan la división por momento de operación (ADR-003) 
- [ ] Si se modificó el `docker-compose.yml`, solo el Frontend expone puerto público al host por defecto (ADR-008) 
- [ ] Si se agregó un workflow de n8n, el JSON exportado está en `src/n8n-workflows/` 
- [ ] Si se agregaron o modificaron prompts, están versionados en `src/ia-ops/prompts/` 
- [ ] Si se invocó un LLM en n8n, el workflow incluye el nodo de envío de traza a Arize Phoenix (ADR-010) 
- [ ] Si se crearon o modificaron tablas, las migraciones SQL están en `src/database/migrations/` (ADR-002)

## Pruebas realizadas
Se creó el archivo `.github/CODEOWNERS` con las rutas y revisores correspondientes. Se activó manualmente "Require review from Code Owners" en Settings → Branches → Branch protection rules de `main`, confirmando en la interfaz que la casilla quedó marcada. Queda pendiente confirmar en un PR de prueba que toque `src/n8n-workflows/` o `src/ia-ops/` que GitHub asigna automáticamente al revisor correcto y bloquea el merge sin su aprobación.

Se evaluaron las reglas "Require signed commits" y "Restrict who can push to matching branches":
- **Require signed commits:** no activada. Exigiría que todo el equipo configure firma de commits (GPG/SSH) en su entorno local, lo cual introduce fricción operativa sin una amenaza concreta que lo justifique en este sprint. Queda como candidata a activar en un sprint posterior si el Arquitecto lo considera necesario.
- **Restrict who can push to matching branches:** no activada, por ser en gran parte redundante con la configuración actual — "Require a pull request before merging" junto con "Do not allow bypassing the above settings" (ya activa) ya impide que cualquier colaborador, incluidos administradores, haga push directo a `main` sin pasar por PR revisado.

## Nota para el Arquitecto
El `CODEOWNERS` asigna `@Andy-2214` y `@edgvrz` como revisores obligatorios de sus respectivas carpetas, según lo confirmado en el listado de colaboradores del repositorio (Settings → Collaborators). Si alguno de los dos cambia de rol o carpeta de responsabilidad, este archivo debe actualizarse en consecuencia. Quedan documentadas pero no activadas las reglas de firma de commits y restricción de push, disponibles para reevaluar más adelante.

## Checklist antes de solicitar revisión
- [x] El código corre localmente sin errores
- [ ] Los pipelines de GitHub Actions pasan (verde)
- [x] El PR tiene el ID del Issue en la sección "Issue relacionado"
- [x] El título del PR describe claramente el cambio
- [ ] Se asignó al Arquitecto como Reviewer en GitHub