### PR TITLE
Ramos tapia frontend

### DIFF
--- a/src/frontend/Produccion/healthradar-Frontend/src/app/api/historicos/route.js
+++ b/src/frontend/Produccion/healthradar-Frontend/src/app/api/historicos/route.js
@@ -1,0 +1,30 @@
+export async function POST(request) {
+  try {
+    const body = await request.json()
+    const n8nUrl = process.env.N8N_INTERNAL_URL || 'http://n8n:5678'
+
+    const res = await fetch(`${n8nUrl}/webhook/historicos`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    if (!res.ok) {
+      return new Response(JSON.stringify({ error: `n8n respondió con código ${res.status}` }), {
+        status: res.status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const data = await res.json()
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    return new Response(JSON.stringify({ error: 'Error interno conectando con n8n: ' + error.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/src/frontend/Produccion/healthradar-Frontend/src/app/historicos/page.js
+++ b/src/frontend/Produccion/healthradar-Frontend/src/app/historicos/page.js
@@ -23,7 +23,7 @@ export default function HistoricosPage() {
     setCargando(true)
     setError('')
     try {
-      const res = await fetch('http://localhost:5678/webhook/historicos', {
+      const res = await fetch('http://n8n:5678/webhook/historicos', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tabla: tablaElegida, pagina: paginaElegida }),

--- a/src/frontend/Produccion/healthradar-Frontend/src/app/historicos/page.js
+++ b/src/frontend/Produccion/healthradar-Frontend/src/app/historicos/page.js
@@ -23,7 +23,7 @@ export default function HistoricosPage() {
     setCargando(true)
     setError('')
     try {
-      const res = await fetch('http://n8n:5678/webhook/historicos', {
+      const res = await fetch('/api/historicos', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tabla: tablaElegida, pagina: paginaElegida }),

--- a/src/frontend/Produccion/healthradar-Frontend/src/app/page.js
+++ b/src/frontend/Produccion/healthradar-Frontend/src/app/page.js
@@ -32,7 +32,7 @@ export default function Page() {
     setError('')
 
     try {
-      const res = await fetch('http://localhost:5678/webhook/consulta', {
+      const res = await fetch('http://n8n:5678/webhook/consulta', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ pregunta: preguntaActual }),


### PR DESCRIPTION
## Descripción del cambio

se añadio la carpeta api para la conexion del frontend con el n8n en el azure


## Issue relacionado

Closes #

## Autor y rol

- **Nombre:** Andy Ramos Tapia
- **Rol en la célula:** Frontend

## Tipo de cambio

<!-- Marca con una X lo que aplique -->

- [ ] Nueva funcionalidad
- [X] Corrección de bug
- [ ] Refactor (sin cambio de funcionalidad)
- [ ] Documentación / ADR
- [ ] Infraestructura / CI-CD
- [ ] Base de datos (migración SQL)
- [ ] Workflow de n8n (JSON exportado)
- [ ] Prompt Engineering (ia-ops)

## Archivos modificados

<!-- Lista los archivos principales que cambia este PR y qué hace cada uno -->

-historicos/page.js
-app/page.js

## Verificación de seguridad

- [X] No hay credenciales, tokens ni API keys escritos en el código fuente
- [X] No hay archivos `.env` incluidos en el commit
- [ ] Las variables sensibles están en `.env`, no en el `docker-compose.yml`
- [ ] Las rutas de API de Next.js no exponen URLs de webhook al navegador (`NEXT_PUBLIC_` no se usó para credenciales)
- [ ] Si se modificó un JSON de n8n, no contiene credenciales en texto plano dentro del JSON

## Cumplimiento de arquitectura

- [X] El Frontend no llama directamente a PostgreSQL ni a ninguna API de IA
- [X] Todo flujo de datos pasa por n8n (Frontend → /api/query → n8n → DB/LLM) (ADR-001/004)
- [ ] Los flujos de IA respetan la división por momento de operación: Gemini Flash para ingesta PDF y Claude Haiku para consultas NLQ (ADR-003)
- [ ] Si se modificó el `docker-compose.yml`, solo el Frontend expone puerto público al host por defecto (ADR-008)
- [ ] Si se agregó un workflow de n8n, el JSON exportado está en `src/n8n-workflows/`
- [ ] Si se agregaron o modificaron prompts, están versionados en `src/ia-ops/prompts/` y no hardcodeados
- [ ] Si se invocó un LLM en n8n, el workflow incluye el nodo de envío de traza a Arize Phoenix (ADR-010)
- [ ] Si se crearon o modificaron tablas, las migraciones SQL están en `src/database/migrations/` (ADR-002)

## Pruebas realizadas

## Nota para el Arquitecto


## Checklist antes de solicitar revisión

- [X] El código corre localmente sin errores
- [X] Los pipelines de GitHub Actions pasan (verde)
- [ ] El PR tiene el ID del Issue en la sección "Issue relacionado"
- [X] El título del PR describe claramente el cambio
- [X] Se asignó al Arquitecto como Reviewer en GitHub
