### PR TITLE
feat: agrega pipeline de despliegue continuo a la VM de Azure (HU-07)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Desplegar en VM de Azure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detectar cambios desplegables
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            deployable:
+              - 'src/**'
+              - 'infrastructure/**'
+
+      - name: Desplegar vía SSH
+        if: steps.filter.outputs.deployable == 'true'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.AZURE_VM_HOST }}
+          username: ${{ secrets.AZURE_VM_USER }}
+          key: ${{ secrets.AZURE_VM_SSH_KEY }}
+          script: |
+            set -e
+            cd /home/azureuser/HealthRadar
+            echo "📥 Actualizando código..."
+            git pull origin main
+            cd infrastructure
+            echo "🐳 Reconstruyendo y desplegando contenedores..."
+            docker compose up -d --build
+            echo "✅ Verificando estado de los servicios..."
+            docker compose ps
+
+      - name: Sin cambios desplegables
+        if: steps.filter.outputs.deployable == 'false'
+        run: echo "✅ Este push no toca src/ ni infrastructure/ — se omite el despliegue"


### PR DESCRIPTION
## Descripción del cambio
Se agrega el pipeline de Despliegue Continuo (CD) del proyecto. Se crea el workflow `deploy.yml`, disparado automáticamente al hacer push a `main` (es decir, cuando un PR ya revisado se fusiona). El job se conecta por SSH a la VM oficial de Azure (reutilizando la llave dedicada de CI ya configurada en HU-05), actualiza el código con `git pull` y reconstruye/reinicia los contenedores con `docker compose up -d --build` sobre el `docker-compose.yml` existente en `infrastructure/`. Se usa `dorny/paths-filter` para que el despliegue real solo se dispare cuando el push toca `src/` o `infrastructure/`, evitando desplegar innecesariamente ante cambios que solo afectan documentación u otros archivos no desplegables.

## Issue relacionado
Closes #52

## Autor y rol
- **Nombre:** Herbert Jhon Choqqueccota Cahui
- **Rol en la célula:** DevSecOps

## Tipo de cambio
- [x] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor (sin cambio de funcionalidad)
- [ ] Documentación / ADR
- [x] Infraestructura / CI-CD
- [ ] Base de datos (migración SQL)
- [ ] Workflow de n8n (JSON exportado)
- [ ] Prompt Engineering (ia-ops)

## Archivos modificados
- `.github/workflows/deploy.yml` — nuevo workflow de despliegue continuo, disparado en push a `main`, con filtrado de rutas y despliegue vía SSH a la VM de Azure.

## Verificación de seguridad
- [x] No hay credenciales, tokens ni API keys escritos en el código fuente
- [x] No hay archivos `.env` incluidos en el commit
- [x] Las variables sensibles están en `.env`, no en el `docker-compose.yml`
- [ ] Las rutas de API de Next.js no exponen URLs de webhook al navegador 
- [ ] Si se modificó un JSON de n8n, no contiene credenciales en texto plano dentro del JSON 

## Cumplimiento de arquitectura
- [ ] El Frontend no llama directamente a PostgreSQL ni a ninguna API de IA 
- [ ] Todo flujo de datos pasa por n8n (Frontend → /api/query → n8n → DB/LLM) (ADR-001/004)
- [ ] Los flujos de IA respetan la división por momento de operación (ADR-003) — *no aplica a este PR*
- [x] Si se modificó el `docker-compose.yml`, solo el Frontend expone puerto público al host por defecto (ADR-008) 
- [ ] Si se agregó un workflow de n8n, el JSON exportado está en `src/n8n-workflows/` 
- [ ] Si se agregaron o modificaron prompts, están versionados en `src/ia-ops/prompts/`
- [ ] Si se invocó un LLM en n8n, el workflow incluye el nodo de envío de traza a Arize Phoenix (ADR-010) 
- [ ] Si se crearon o modificaron tablas, las migraciones SQL están en `src/database/migrations/` (ADR-002) 

## Pruebas realizadas
Se validó la sintaxis del YAML (`python3 -m yaml`, sin errores). Se confirmó manualmente la ruta del proyecto en la VM (`/home/azureuser/HealthRadar/infrastructure/docker-compose.yml`), conectándose por SSH con la llave dedicada `healthradar_gha_deploy`. **Pendiente:** fusionar este PR a `main` para confirmar que el job se dispara correctamente y que el despliegue real (`git pull` + `docker compose up -d --build`) se ejecuta sin errores en la VM.

## Nota para el Arquitecto
Este pipeline reutiliza los mismos secrets SSH configurados en HU-05 (`AZURE_VM_HOST`, `AZURE_VM_USER`, `AZURE_VM_SSH_KEY`), sin exponer ningún puerto adicional, conforme a ADR-008/ADR-011. El despliegue **no** tiene `continue-on-error`, a diferencia de la validación de HU-05 — si el `git pull` o el `docker compose up` fallan, el job se marca como fallido intencionalmente, para que el equipo se entere de inmediato de un despliegue roto. El plan de rollback documentado: ante un despliegue fallido, revertir el commit problemático en `main` (`git revert`) y dejar que el pipeline lo redepliegue automáticamente; o, para una recuperación más rápida, conectarse por SSH y ejecutar manualmente `cd /home/azureuser/HealthRadar && git checkout <commit-estable> && cd infrastructure && docker compose up -d --build`.

## Checklist antes de solicitar revisión
- [x] El código corre localmente sin errores
- [ ] Los pipelines de GitHub Actions pasan (verde) 
- [x] El PR tiene el ID del Issue en la sección "Issue relacionado"
- [x] El título del PR describe claramente el cambio
- [ ] Se asignó al Arquitecto como Reviewer en GitHub