### PR TITLE
feat: agrega src/frontend a las carpetas cubiertas por Andy en CODEOW…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,9 @@
 # Cada línea asigna revisores obligatorios para las rutas indicadas.
 # Ver: https://docs.github.com/articles/about-code-owners
 
+# Frontend - requiere revisión de Full Stack
+/src/frontend/ @Andy-2214
+
 # Workflows de n8n - requiere revisión de Backend/Full Stack
 /src/n8n-workflows/ @Andy-2214
 


### PR DESCRIPTION
## Descripción del cambio
Se amplió el archivo .github/CODEOWNERS para incluir la carpeta src/frontend/, asignando a @Andy-2214 (rol Full Stack/Backend) como revisor obligatorio de esa ruta. Esto forma parte del endurecimiento de las Branch Protection Rules de main, para que los cambios en carpetas críticas del proyecto requieran la aprobación de quien es responsable de esa área.

## Issue relacionado


## Autor y rol
- **Nombre:** Herbert Jhon Choqqueccota Cahui
- **Rol en la célula:** DevSecOps

## Tipo de cambio
- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor (sin cambio de funcionalidad)
- [ ] Documentación / ADR
- [x] Infraestructura / CI-CD
- [ ] Base de datos (migración SQL)
- [ ] Workflow de n8n (JSON exportado)
- [ ] Prompt Engineering (ia-ops)

## Archivos modificados
- `.github/CODEOWNERS` — se agregó la sección "Frontend - requiere revisión de Full Stack" asignando /src/frontend/ a @Andy-2214.

## Verificación de seguridad
- [x] No hay credenciales, tokens ni API keys escritos en el código fuente
- [x] No hay archivos `.env` incluidos en el commit
- [x] Las variables sensibles están en `.env`, no en el `docker-compose.yml`
- [x] Las rutas de API de Next.js no exponen URLs de webhook al navegador (`NEXT_PUBLIC_` no se usó para credenciales)
- [x] Si se modificó un JSON de n8n, no contiene credenciales en texto plano dentro del JSON

## Cumplimiento de arquitectura
- [x] El Frontend no llama directamente a PostgreSQL ni a ninguna API de IA
- [x] Todo flujo de datos pasa por n8n (Frontend → /api/query → n8n → DB/LLM) (ADR-001/004)
- [ ] Los flujos de IA respetan la división por momento de operación: Gemini Flash para ingesta PDF y Claude Haiku para consultas NLQ (ADR-003) — *no aplica a este cambio*
- [ ] Si se modificó el `docker-compose.yml`, solo el Frontend expone puerto público al host por defecto (ADR-008) 
- [ ] Si se agregó un workflow de n8n, el JSON exportado está en `src/n8n-workflows/
- [ ] Si se agregaron o modificaron prompts, están versionados en `src/ia-ops/prompts/` y no hardcodeados
- [ ] Si se invocó un LLM en n8n, el workflow incluye el nodo de envío de traza a Arize Phoenix (ADR-010) 
- [ ] Si se crearon o modificaron tablas, las migraciones SQL están en `src/database/migrations/` (ADR-002) 

## Pruebas realizadas
Se verificó en la vista de comparación del PR que GitHub reconoce el archivo como válido ("This CODEOWNERS file is valid"), confirmando que la sintaxis y el usuario asignado (@Andy-2214) son correctos y quedarán activos como revisor obligatorio de src/frontend/.

## Nota para el Arquitecto
Este CODEOWNERS aún no está vinculado a la regla "Require review from Code Owners" en Branch Protection Rules — ese es el siguiente paso pendiente de esta historia (HU-06), una vez que se confirme con el resto del equipo qué carpetas debe cubrir cada rol.

## Checklist antes de solicitar revisión
- [x] El código corre localmente sin errores
- [x] Los pipelines de GitHub Actions pasan (verde)
- [ ] El PR tiene el ID del Issue en la sección "Issue relacionado" 
- [x] El título del PR describe claramente el cambio
- [ ] Se asignó al Arquitecto como Reviewer en GitHub 