### PR TITLE
feat(ci/cd): agregar disparador manual workflow_dispatch

### DIFF
--- a/.github/workflows/n8n-deploy-cd.yml
+++ b/.github/workflows/n8n-deploy-cd.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - "src/n8n-workflows/production/**"
+  workflow_dispatch:
 
 jobs:
   deploy-n8n:


### PR DESCRIPTION
## Descripción del cambio

Habilita el disparador manual `workflow_dispatch` en el pipeline de despliegue continuo (`n8n-deploy-cd.yml`). 

Esto permite al equipo de operaciones y arquitectura ejecutar el despliegue, importación y publicación automática (botón Publish) de los flujos de n8n en la máquina virtual directamente desde la interfaz web de GitHub Actions mediante el botón **"Run workflow"**, sin necesidad de crear commits ficticios o innecesarios.

## Issue relacionado

Closes 

## Autor y rol

- **Nombre:** Roberto Arturo Bautista Anampa
- **Rol en la célula:** Arquitecto

## Tipo de cambio

- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactor (sin cambio de funcionalidad)
- [ ] Documentación / ADR
- [X] Infraestructura / CI-CD
- [ ] Base de datos (migración SQL)
- [ ] Workflow de n8n (JSON exportado)
- [ ] Prompt Engineering (ia-ops)

## Archivos modificados

- `.github/workflows/n8n-deploy-cd.yml`: Se añade la directiva `workflow_dispatch:` en los eventos de activación (`on:`).

## Verificación de seguridad

- [X] No hay credenciales, tokens ni API keys escritos en el código fuente
- [X] No hay archivos `.env` incluidos en el commit
- [X] Las variables sensibles están en `.env`, no en el `docker-compose.yml`
- [X] Las rutas de API de Next.js no exponen URLs de webhook al navegador (`NEXT_PUBLIC_` no se usó para credenciales)
- [X] Si se modificó un JSON de n8n, no contiene credenciales en texto plano dentro del JSON

## Cumplimiento de arquitectura

- [X] El Frontend no llama directamente a PostgreSQL ni a ninguna API de IA
- [X] Todo flujo de datos pasa por n8n (Frontend → /api/query → n8n → DB/LLM) (ADR-001/004)
- [X] Los flujos de IA respetan la división por momento de operación: Gemini Flash para ingesta PDF y Claude Haiku para consultas NLQ (ADR-003)
- [X] Si se modificó el `docker-compose.yml`, solo el Frontend expone puerto público al host por defecto (ADR-008)
- [X] Si se agregó un workflow de n8n, el JSON exportado está en `src/n8n-workflows/`
- [X] Si se agregaron o modificaron prompts, están versionados en `src/ia-ops/prompts/` y no hardcodeados
- [X] Si se invocó un LLM en n8n, el workflow incluye el nodo de envío de traza a Arize Phoenix (ADR-010)
- [X] Si se crearon o modificaron tablas, las migraciones SQL están en `src/database/migrations/` (ADR-002)


## Nota para DevSecOps / Revisores

- Es un cambio de 1 sola línea en el YAML para habilitar la ejecución manual controlada desde GitHub Actions y poder desplegar los 4 flujos de n8n que ya están en `main`.

## Checklist antes de solicitar revisión

- [X] El código corre localmente sin errores
- [X] Los pipelines de GitHub Actions pasan (verde)
- [ ] El PR tiene el ID del Issue en la sección "Issue relacionado"
- [X] El título del PR describe claramente el cambio
- [X] Se asignó a DevSecOps como Reviewer en GitHub
